### PR TITLE
Allow manual pagination of API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,55 @@ Result:
     </li>
 </ul>
 ```
+
+### Manual pagination
+
+Usually the client will return all matching records at once. But this is not
+always desired. Instead you may want to load the results in smaller chunks. This
+is called *pagination*.
+
+For example if you like to get only the first 15 persons of ChurchTools:
+
+```php
+
+use CTApi\Requests\PersonRequest;
+
+$persons = PersonRequest::where('page', 1)
+    ->where('limit', 15)
+    ->get();
+
+// To get the next 15 persons query for the second page:
+$persons = PersonRequest::where('page', 2)
+    ->where('limit', 15)
+    ->get();
+```
+
+This is possible for the other APIs like event or group, too.
+
+
+#### Iterate over all pages
+
+Iterating over all records is quite easy.
+
+```php
+
+use CTApi\Requests\PersonRequest;
+
+$page = 1;
+$limit = 15;
+
+do {
+    $persons = PersonRequest::where('page', $page)
+        ->where('limit', $limit)
+        ->get();
+
+    // do some stuff with the persons
+
+    $page++;
+} while (count($persons) === $limit);
+```
+
+
 ## Support / Contribute
 
 Please feel free to Support or Contribute this project.

--- a/src/Requests/Traits/Pagination.php
+++ b/src/Requests/Traits/Pagination.php
@@ -13,11 +13,17 @@ trait Pagination
         $client = CTClient::getClient();
         $collectedData = [];
 
-        // Add Page Information to Options
-        if (!array_key_exists("json", $options)) {
-            $options["json"] = [];
+        if (isset($options["json"]["page"])) {
+            $manualPagination = true;
+        } else {
+            // Add Page Information to Options
+            if (!array_key_exists("json", $options)) {
+                $options["json"] = [];
+            }
+            $options["json"]["page"] = 1;
+
+            $manualPagination = false;
         }
-        $options["json"]["page"] = 1;
 
         //Collect Data from First Page
         $response = $client->get($url, $options);
@@ -26,7 +32,7 @@ trait Pagination
         $collectedData = array_merge($collectedData, CTResponseUtil::dataAsArray($response));
 
 
-        if (array_key_exists("pagination", $metaInformation)) {
+        if (!$manualPagination && array_key_exists("pagination", $metaInformation)) {
             $lastPage = $metaInformation["pagination"]["lastPage"];
 
             // Collect Date from Second till Last page


### PR DESCRIPTION
Currently it is not able to paginate the results of the API manually. The `Pagination` trait always iterates over all pages automatically, which is not always desired. I have already created the issue #68.

In my case for example, I want to synchronize a custom member list (see [this repo](https://github.com/naitsirch/ecgpb-memberlist) interactively via cli command. I want to compare each person and show the differences between the local and the remote data.

The user should be able to exit the comparison. This is why it would be useless to fetch hundreds of data records if only maybe 10 are needed.

The change is very simple. The pagination trait will check if the options contains a specific page. If any is set it will only load this specific page. Otherwise it will fall back to the previois behaviour and iterate over all pages. So backward compatibility is kept ;-)

I am going to add an explanation to the documentation, too. Aferwards I'll update this PR.