### PR TITLE
Added method to delete a person on churchtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [Added method to update person data](https://github.com/5pm-HDH/churchtools-api/pull/84)
 - [Added modifiable-attributes to person-api docs](https://github.com/5pm-HDH/churchtools-api/pull/88)
+- [Added method to delete person records](https://github.com/5pm-HDH/churchtools-api/pull/91)
 
 ### Changed
 - [Refactor CTClient:](https://github.com/5pm-HDH/churchtools-api/pull/83) transform inheritance from GuzzleClient to composition-relation

--- a/docs/out/PersonAPI.md
+++ b/docs/out/PersonAPI.md
@@ -46,6 +46,7 @@ Follow this example:
 ```php
         use CTApi\Requests\PersonRequest;
 
+        $person = PersonRequest::findOrFail(21);
         $person->setEmail('new-mail@example.com');
 
         PersonRequest::update($person);
@@ -60,6 +61,7 @@ data sent to the API, by adding a whitelist of attributes.
 ```php
         use CTApi\Requests\PersonRequest;
 
+        $person = PersonRequest::findOrFail(21);
         $person->setEmail('new-mail@example.com');
         $person->setJob('This should not be persisted!');
 
@@ -75,11 +77,26 @@ The following attributes can be updated:
 ```php
         use CTApi\Requests\PersonRequest;
 
+        $person = PersonRequest::findOrFail(21);
 
         // Attributes that can be updated in ChurchTools-API
         $listOfModifiableAttributes = implode("; ", $person->getModifiableAttributes());
         var_dump( $listOfModifiableAttributes);
         // Output: "addressAddition; birthday; birthName; birthplace; city; country; email; fax; firstName; job; lastName; mobile; nickname; phonePrivate; phoneWork; sexId; street; zip"
 
+
+```
+
+## Delete person
+
+Delete person via PersonRequest:
+
+```php
+        use CTApi\Requests\PersonRequest;
+
+        $person = PersonRequest::findOrFail(21);
+
+        // delete person on churchtools
+        PersonRequest::delete($person);
 
 ```

--- a/docs/src/ressources/PersonAPI.md
+++ b/docs/src/ressources/PersonAPI.md
@@ -24,3 +24,9 @@ unnecessary traffic if you are going to do some bulk updates.
 The following attributes can be updated:
 
 {{ \Tests\Unit\Docs\PersonRequestTest.testUpdatePersonModifiableAttributes }}
+
+## Delete person
+
+Delete person via PersonRequest:
+
+{{ \Tests\Unit\Docs\PersonRequestTest.testDeletePerson }}

--- a/src/CTClient.php
+++ b/src/CTClient.php
@@ -60,6 +60,16 @@ class CTClient
         }
     }
 
+    public function delete($uri, array $options = []): ResponseInterface
+    {
+        try {
+            CTLog::getLog()->debug('CTClient: DELETE-Request URI:' . $uri, ["options" => $options, "mergedOptions" => self::mergeOptions($options)]);
+            return $this->handleResponse($this->guzzleClient->delete($uri, self::mergeOptions($options)));
+        } catch (Exception $exception) {
+            return $this->handleException($exception);
+        }
+    }
+
     private function handleResponse(ResponseInterface $response): ResponseInterface
     {
         switch ($response->getStatusCode()) {

--- a/src/Requests/AbstractRequestBuilder.php
+++ b/src/Requests/AbstractRequestBuilder.php
@@ -110,6 +110,21 @@ abstract class AbstractRequestBuilder
         $this->updateData($modelId, $updateAttributes);
     }
 
+    /**
+     * Delete the object in ChurchTools by the given ID.
+     */
+    public function delete(string $modelId): void
+    {
+        $url = $this->getApiEndpoint() . '/' . $modelId;
+
+        $client = CTClient::getClient();
+        $response = $client->delete($url);
+
+        if (!in_array($response->getStatusCode(), [200, 204])) {
+            throw CTRequestException::ofErrorResponse($response);
+        }
+    }
+
     abstract protected function getApiEndpoint(): string;
 
     abstract protected function getModelClass(): string;

--- a/src/Requests/PersonRequest.php
+++ b/src/Requests/PersonRequest.php
@@ -3,6 +3,7 @@
 
 namespace CTApi\Requests;
 
+use CTApi\Exceptions\CTModelException;
 use CTApi\Models\Person;
 
 class PersonRequest
@@ -57,6 +58,12 @@ class PersonRequest
      */
     public static function delete(Person $person): void
     {
-        (new PersonRequestBuilder())->delete($person->getId());
+        $id = $person->getId();
+
+        if (is_null($id)) {
+            throw new CTModelException("ID of Person cannot be null.");
+        }
+
+        (new PersonRequestBuilder())->delete($id);
     }
 }

--- a/src/Requests/PersonRequest.php
+++ b/src/Requests/PersonRequest.php
@@ -51,4 +51,12 @@ class PersonRequest
     {
         (new PersonRequestBuilder())->update($person, $attributesToUpdate);
     }
+
+    /**
+     * Delete the person on churchtools.
+     */
+    public static function delete(Person $person): void
+    {
+        (new PersonRequestBuilder())->delete($person->getId());
+    }
 }

--- a/tests/unit/Docs/PersonRequestTest.php
+++ b/tests/unit/Docs/PersonRequestTest.php
@@ -43,7 +43,8 @@ class PersonRequestTest extends TestCaseHttpMocked
     /**
      * @doesNotPerformAssertions
      */
-    public function testUpdatePerson(){
+    public function testUpdatePerson()
+    {
         $person = PersonRequest::findOrFail(21);
         $person->setEmail('new-mail@example.com');
 
@@ -53,7 +54,8 @@ class PersonRequestTest extends TestCaseHttpMocked
     /**
      * @doesNotPerformAssertions
      */
-    public function testUpdatePersonSingleAttrbute(){
+    public function testUpdatePersonSingleAttrbute()
+    {
         $person = PersonRequest::findOrFail(21);
         $person->setEmail('new-mail@example.com');
         $person->setJob('This should not be persisted!');
@@ -61,11 +63,23 @@ class PersonRequestTest extends TestCaseHttpMocked
         PersonRequest::update($person, ['email']);
     }
 
-    public function testUpdatePersonModifiableAttributes(){
+    public function testUpdatePersonModifiableAttributes()
+    {
         $person = PersonRequest::findOrFail(21);
 
         // Attributes that can be updated in ChurchTools-API
         $listOfModifiableAttributes = implode("; ", $person->getModifiableAttributes());
         $this->assertEquals("addressAddition; birthday; birthName; birthplace; city; country; email; fax; firstName; job; lastName; mobile; nickname; phonePrivate; phoneWork; sexId; street; zip", $listOfModifiableAttributes);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testDeletePerson()
+    {
+        $person = PersonRequest::findOrFail(21);
+
+        // delete person on churchtools
+        PersonRequest::delete($person);
     }
 }


### PR DESCRIPTION
As a follow up to #84 I'd like to add a method to call the API endpoint to delete a person record.

It is quite simple to use:

```php
use CTApi\Requests\PersonRequest;

$personA = PersonRequest::find(21);
PersonRequest::delete($personA);
```
I haven't added documentation or unit tests, because your way of writing those is a bit hard to follow for me :-)
It would be nice if you could do that.