### PR TITLE
Use query parameters in GET requests for filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Status-Code handling and Exception-handling](https://github.com/5pm-HDH/churchtools-api/pull/99)
 - [Refactor delete person](https://github.com/5pm-HDH/churchtools-api/pull/100)
 - [Refactor FillWithData](https://github.com/5pm-HDH/churchtools-api/pull/101)
+- [Refactor: Use Query-Parameters for Where-Clause](https://github.com/5pm-HDH/churchtools-api/pull/106)
 
 ### Fixed
 

--- a/src/Requests/PersonRequestBuilder.php
+++ b/src/Requests/PersonRequestBuilder.php
@@ -21,7 +21,7 @@ class PersonRequestBuilder extends AbstractRequestBuilder
     public function get(): array
     {
         $options = [
-            "json" => []
+            "query" => []
         ];
 
         //Where-Clauses

--- a/src/Requests/Traits/Pagination.php
+++ b/src/Requests/Traits/Pagination.php
@@ -13,14 +13,14 @@ trait Pagination
         $client = CTClient::getClient();
         $collectedData = [];
 
-        if (isset($options["json"]["page"])) {
+        if (isset($options["query"]["page"])) {
             $manualPagination = true;
         } else {
             // Add Page Information to Options
-            if (!array_key_exists("json", $options)) {
-                $options["json"] = [];
+            if (!array_key_exists("query", $options)) {
+                $options["query"] = [];
             }
-            $options["json"]["page"] = 1;
+            $options["query"]["page"] = 1;
 
             $manualPagination = false;
         }
@@ -37,7 +37,7 @@ trait Pagination
 
             // Collect Date from Second till Last page
             for ($i = 2; $i <= $lastPage; $i++) {
-                $options["json"]["page"] = $i;
+                $options["query"]["page"] = $i;
 
                 $response = $client->get($url, $options);
 

--- a/src/Requests/Traits/WhereCondition.php
+++ b/src/Requests/Traits/WhereCondition.php
@@ -21,12 +21,12 @@ trait WhereCondition
 
     protected function addWhereConditionsToOption(&$options): void
     {
-        if (!array_key_exists("json", $options)) {
-            $options["json"] = [];
+        if (!array_key_exists("query", $options)) {
+            $options["query"] = [];
         }
 
         foreach ($this->whereCriteria as $whereKey => $whereValue) {
-            $options["json"][$whereKey] = $whereValue;
+            $options["query"][$whereKey] = $whereValue;
         }
     }
 }

--- a/tests/unit/HttpMock/HttpMockDataResolver.php
+++ b/tests/unit/HttpMock/HttpMockDataResolver.php
@@ -39,7 +39,7 @@ class HttpMockDataResolver
         // convert string to lowercase
         $endpoint = strtolower($endpoint);
 
-        $pageNr = CTUtil::arrayPathGet($options, "json.page");
+        $pageNr = CTUtil::arrayPathGet($options, "query.page");
         if (!is_null($pageNr) && $pageNr > 1) {
             $endpoint .= "_page_" . $pageNr;
             CTLog::getLog()->debug("Append Page-Number to Endpoint-Filename: " . $endpoint);


### PR DESCRIPTION
currently this is done with json/body params. It is working, because guzzle magically turns body params into query params when doing GET requests, but imho this is not clean and we should not rely on this behaviour.