### PR TITLE
Sending API key as HTTP header instead of query param in FileRequestBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Sending API key as HTTP header instead of query param in FileRequestBuilder ([PR126](https://github.com/5pm-HDH/churchtools-api/pull/126))
+
 ### Fixed
 
 ## [1.3.5] - 2022-09-22

--- a/src/Requests/FileRequestBuilder.php
+++ b/src/Requests/FileRequestBuilder.php
@@ -54,10 +54,12 @@ class FileRequestBuilder
         }
 
         $csrfToken = CSRFTokenRequest::getOrFail();
+        $url = rtrim(CTConfig::getApiUrl(), '/') . $this->getApiEndpoint();
 
         // Upload file with pure CURL
-        $ch = curl_init(CTConfig::getApiUrl() . $this->getApiEndpoint() . "?login_token=" . CTConfig::getApiKey());
+        $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "authorization: Login " . CTConfig::getApiKey(),
             "content-type:multipart/form-data",
             "csrf-token:" . $csrfToken
         ]);

--- a/src/Requests/FileRequestBuilder.php
+++ b/src/Requests/FileRequestBuilder.php
@@ -7,6 +7,7 @@ namespace CTApi\Requests;
 use CTApi\CTClient;
 use CTApi\CTConfig;
 use CTApi\CTLog;
+use CTApi\Exceptions\CTConfigException;
 use CTApi\Exceptions\CTModelException;
 use CTApi\Exceptions\CTRequestException;
 use CTApi\Models\File;
@@ -54,7 +55,11 @@ class FileRequestBuilder
         }
 
         $csrfToken = CSRFTokenRequest::getOrFail();
-        $url = rtrim(CTConfig::getApiUrl(), '/') . $this->getApiEndpoint();
+        $apiUrl = CTConfig::getApiUrl();
+        if(is_null($apiUrl)){
+            throw new CTConfigException("API-Url cannot be null.");
+        }
+        $url = rtrim($apiUrl, '/') . $this->getApiEndpoint();
 
         // Upload file with pure CURL
         $ch = curl_init($url);


### PR DESCRIPTION
Using the HTTP header for this scenario is a little bit cleaner as it is designed exactly for this use case.

Further more eventually existing trailing slashes in the API URL are trimmed to prevent a double slash in the URL like `https://example.church.tools//api/files/...` which may lead to issues.