### PR TITLE
Improved the formatting of ChurchTool's error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Sending API key as HTTP header instead of query param in FileRequestBuilder ([PR126](https://github.com/5pm-HDH/churchtools-api/pull/126))
 - Update ChurchTools from 3.90.0 to 3.91.1 ([PR129](https://github.com/5pm-HDH/churchtools-api/pull/129))
+- Improved the formatting of ChurchTool's error response ([PR132](https://github.com/5pm-HDH/churchtools-api/pull/132))
 
 ### Fixed
 

--- a/src/Exceptions/CTRequestException.php
+++ b/src/Exceptions/CTRequestException.php
@@ -100,13 +100,26 @@ class CTRequestException extends RuntimeException
                 if (array_key_exists('args', $error) && array_key_exists('value', $error['args'])) {
                     $value = $error['args']['value'];
 
-                    if ('' === $value) {
-                        $description .= ' If no e-mail address is available set it to null.';
+                    if (null === $value) {
+                        $description .= ' Provided value was NULL.';
                     } else {
-                        $description .= sprintf('Provided value was "%s".', $value);
+                        $description .= sprintf(' Provided value was "%s".', $value);
                     }
                 }
 
+                $errorDescriptions[] = $description;
+
+                continue;
+            }
+
+            if (isset($error['message'])) {
+                $args = isset($error['args']) && is_array($error['args']) ? $error['args'] : [];
+
+                $placeholders = array_map(function ($key) {
+                    return sprintf('{%s}', $key);
+                }, array_keys($args));
+
+                $description = strtr($error['message'], array_combine($placeholders, $args));
                 $errorDescriptions[] = $description;
 
                 continue;


### PR DESCRIPTION
For example for values which have an invalid length ChurchTool responds with a message template with placeholders. The placeholders can be replaced by the provided args to get a more helpful message.