### PR TITLE
Event: missing/deprecated field

### DIFF
--- a/src/Models/Events/Event/Event.php
+++ b/src/Models/Events/Event/Event.php
@@ -17,6 +17,7 @@ class Event extends AbstractModel
     protected ?string $guid = null;
     protected ?string $name = null;
     protected ?string $description = null;
+    protected ?string $note = null;
     protected ?string $startDate = null;
     protected ?string $endDate = null;
     protected ?bool $chatStatus = null;
@@ -24,6 +25,7 @@ class Event extends AbstractModel
     protected ?DomainAttributeModel $calendar = null;
     protected ?EventAgenda $agenda = null;
     protected ?array $eventServices = [];
+    protected ?array $adminIds = [];
 
     protected function fillArrayType(string $key, array $data): void
     {
@@ -41,6 +43,9 @@ class Event extends AbstractModel
                 if(key_exists("startDate", $data)) {
                     $this->setStartDate($data["startDate"]);
                 }
+                break;
+            case "adminIds":
+                $this->setAdminIds($data);
                 break;
             default:
                 $this->fillDefault($key, $data);
@@ -142,6 +147,7 @@ class Event extends AbstractModel
     }
 
     /**
+     * @deprecated use note
      * @return string|null
      */
     public function getDescription(): ?string
@@ -150,12 +156,31 @@ class Event extends AbstractModel
     }
 
     /**
+     * @deprecated use note
      * @param string|null $description
      * @return Event
      */
     public function setDescription(?string $description): Event
     {
         $this->description = $description;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+    
+    /**
+     * @param string|null $note
+     * @return Event
+     */
+    public function setNote(?string $note): Event
+    {
+        $this->note = $note;
         return $this;
     }
 
@@ -282,6 +307,24 @@ class Event extends AbstractModel
     public function setEventServices(?array $eventServices): Event
     {
         $this->eventServices = $eventServices;
+        return $this;
+    }
+    
+    /**
+     * @return array|null
+     */
+    public function getAdminIds(): ?array
+    {
+        return $this->adminIds;
+    }
+    
+    /**
+     * @param array|null $adminIds
+     * @return Event
+     */
+    public function setAdminIds(?array $adminIds): Event
+    {
+        $this->adminIds = $adminIds;
         return $this;
     }
 }

--- a/src/Models/Events/Event/Event.php
+++ b/src/Models/Events/Event/Event.php
@@ -147,7 +147,7 @@ class Event extends AbstractModel
     }
 
     /**
-     * @deprecated use note
+     * @deprecated use "note"
      * @return string|null
      */
     public function getDescription(): ?string
@@ -156,7 +156,7 @@ class Event extends AbstractModel
     }
 
     /**
-     * @deprecated use note
+     * @deprecated use "note"
      * @param string|null $description
      * @return Event
      */


### PR DESCRIPTION
There are additional fields in the event request (/events), which aren't documented.

- Field "note": This field would replace "description", so "description" is marked as deprecated
- Field "adminIds"

I added those fields in the model (and marked the deprecated one). I would appreciate if you merge my changes.
