### PR TITLE
Moved group type classes to separate namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Retrieve, create and delete SongArrangement comments ([PR187](https://github.com/5pm-HDH/churchtools-api/pull/187))
-- Get GroupTypes ([PR188](https://github.com/5pm-HDH/churchtools-api/pull/188))
+- Get GroupTypes ([PR188](https://github.com/5pm-HDH/churchtools-api/pull/188), [PR198](https://github.com/5pm-HDH/churchtools-api/pull/198))
 - Get GroupTypeRoles ([PR197](https://github.com/5pm-HDH/churchtools-api/pull/197))
 - PHP coding standard ([PR193](https://github.com/5pm-HDH/churchtools-api/pull/193))
 

--- a/docs/out/GroupAPI.md
+++ b/docs/out/GroupAPI.md
@@ -517,8 +517,8 @@
 ## Group-Types
 
 ```php
-        use CTApi\Models\Groups\Group\GroupType;
-        use CTApi\Models\Groups\Group\GroupTypeRequest;
+        use CTApi\Models\Groups\GroupType\GroupType;
+        use CTApi\Models\Groups\GroupType\GroupTypeRequest;
 
         $groupTypes = GroupTypeRequest::all();
 
@@ -534,8 +534,8 @@
 ```
 
 ```php
-        use CTApi\Models\Groups\Group\GroupType;
-        use CTApi\Models\Groups\Group\GroupTypeRequest;
+        use CTApi\Models\Groups\GroupType\GroupType;
+        use CTApi\Models\Groups\GroupType\GroupTypeRequest;
 
         $groupType = GroupTypeRequest::find(2);
 

--- a/src/Models/Groups/GroupType/GroupType.php
+++ b/src/Models/Groups/GroupType/GroupType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CTApi\Models\Groups\Group;
+namespace CTApi\Models\Groups\GroupType;
 
 use CTApi\Models\AbstractModel;
 use CTApi\Traits\Model\FillWithData;

--- a/src/Models/Groups/GroupType/GroupTypeRequest.php
+++ b/src/Models/Groups/GroupType/GroupTypeRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CTApi\Models\Groups\Group;
+namespace CTApi\Models\Groups\GroupType;
 
 class GroupTypeRequest
 {

--- a/src/Models/Groups/GroupType/GroupTypeRequestBuilder.php
+++ b/src/Models/Groups/GroupType/GroupTypeRequestBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CTApi\Models\Groups\Group;
+namespace CTApi\Models\Groups\GroupType;
 
 use CTApi\Models\AbstractRequestBuilder;
 

--- a/src/Models/Groups/GroupTypeRole/GroupTypeRole.php
+++ b/src/Models/Groups/GroupTypeRole/GroupTypeRole.php
@@ -3,8 +3,8 @@
 namespace CTApi\Models\Groups\GroupTypeRole;
 
 use CTApi\Models\AbstractModel;
-use CTApi\Models\Groups\Group\GroupType;
-use CTApi\Models\Groups\Group\GroupTypeRequest;
+use CTApi\Models\Groups\GroupType\GroupType;
+use CTApi\Models\Groups\GroupType\GroupTypeRequest;
 use CTApi\Traits\Model\FillWithData;
 use CTApi\Traits\Model\MetaAttribute;
 

--- a/tests/Integration/Requests/GroupTypeRequestTest.php
+++ b/tests/Integration/Requests/GroupTypeRequestTest.php
@@ -3,7 +3,7 @@
 namespace CTApi\Test\Integration\Requests;
 
 use CTApi\Exceptions\CTRequestException;
-use CTApi\Models\Groups\Group\GroupTypeRequest;
+use CTApi\Models\Groups\GroupType\GroupTypeRequest;
 use CTApi\Test\Integration\IntegrationTestData;
 use CTApi\Test\Integration\TestCaseAuthenticated;
 

--- a/tests/Integration/Requests/GroupTypeRoleRequestTest.php
+++ b/tests/Integration/Requests/GroupTypeRoleRequestTest.php
@@ -3,7 +3,7 @@
 namespace CTApi\Test\Integration\Requests;
 
 use CTApi\CTLog;
-use CTApi\Models\Groups\Group\GroupType;
+use CTApi\Models\Groups\GroupType\GroupType;
 use CTApi\Models\Groups\GroupTypeRole\GroupTypeRole;
 use CTApi\Models\Groups\GroupTypeRole\GroupTypeRoleRequest;
 use CTApi\Test\Integration\IntegrationTestData;

--- a/tests/Unit/Docs/GroupTypeRequestTest.php
+++ b/tests/Unit/Docs/GroupTypeRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace CTApi\Test\Unit\Docs;
 
-use CTApi\Models\Groups\Group\GroupType;
-use CTApi\Models\Groups\Group\GroupTypeRequest;
+use CTApi\Models\Groups\GroupType\GroupType;
+use CTApi\Models\Groups\GroupType\GroupTypeRequest;
 use CTApi\Test\Unit\TestCaseHttpMocked;
 
 class GroupTypeRequestTest extends TestCaseHttpMocked


### PR DESCRIPTION
I would like to move the group type classes to a separate namespace, because I think it is more consistent to place the group type classes to their own namespace like other models.

What do you think?