### PR TITLE
Feature: Login with Session Cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Get GroupTypeRoles ([PR197](https://github.com/5pm-HDH/churchtools-api/pull/197))
 - PHP coding standard ([PR193](https://github.com/5pm-HDH/churchtools-api/pull/193))
 - Added new property 'postsEnabled' to the group type model ([PR204](https://github.com/5pm-HDH/churchtools-api/pull/204))
+- Login with Session Cookie ([PR207](https://github.com/5pm-HDH/churchtools-api/pull/207))
 
 ### Changed
 

--- a/src/CTConfig.php
+++ b/src/CTConfig.php
@@ -159,7 +159,7 @@ class CTConfig
         if (empty($cookieData)) {
             return null;
         }
-        return end($cookieData);
+        return array_pop($cookieData);
     }
 
     public static function getSessionCookieString(): ?string

--- a/src/CTConfig.php
+++ b/src/CTConfig.php
@@ -168,6 +168,12 @@ class CTConfig
         return $cookieData ? (string) (new SetCookie($cookieData)) : null;
     }
 
+    public static function setSessionCookie(string $cookieString): void
+    {
+        $cookie = SetCookie::fromString($cookieString);
+        self::getConfig()->cookieJar->setCookie($cookie);
+    }
+
     /**
      * @see CTConfig::authWithLoginToken()
      * @deprecated Will be removed in further version. Use <code>CTConfig::authWithLoginToken()</code> instead.

--- a/src/CTConfig.php
+++ b/src/CTConfig.php
@@ -10,6 +10,7 @@ use CTApi\Models\Common\Auth\AuthRequest;
 use CTApi\Models\Groups\Person\PersonRequest;
 use CTApi\Utils\CTUtil;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\TransferStats;
 use Kevinrob\GuzzleCache\CacheMiddleware;
@@ -133,6 +134,11 @@ class CTConfig
         return AuthRequest::authWithLoginToken($loginToken);
     }
 
+    public static function authWithSessionCookie(string $cookieString): Auth
+    {
+        return AuthRequest::authWithSessionCookie($cookieString);
+    }
+
     /**
      * Auth via undocumented ajax-API. Use <code>authWithLoginToken()</code> instead.
      * @param string $userId
@@ -154,6 +160,12 @@ class CTConfig
             return null;
         }
         return end($cookieData);
+    }
+
+    public static function getSessionCookieString(): ?string
+    {
+        $cookieData = self::getSessionCookie();
+        return $cookieData ? (string) (new SetCookie($cookieData)) : null;
     }
 
     /**

--- a/src/Models/Common/Auth/AuthRequest.php
+++ b/src/Models/Common/Auth/AuthRequest.php
@@ -18,6 +18,12 @@ class AuthRequest
         return (new AuthRequestBuilder())->authWithLoginToken($loginToken);
     }
 
+    public static function authWithSessionCookie(string $sessionCookie): Auth
+    {
+        CTLog::getLog()->info('AuthRequest: Authenticate CTConfig with Session');
+        return (new AuthRequestBuilder())->authWithSessionCookie($sessionCookie);
+    }
+
     public static function authWithUserIdAndLoginToken(string $userId, string $loginToken): bool
     {
         CTLog::getLog()->info('AuthRequest: Authenticate CTConfig with UserId and Token.');

--- a/src/Models/Common/Auth/AuthRequestBuilder.php
+++ b/src/Models/Common/Auth/AuthRequestBuilder.php
@@ -7,6 +7,7 @@ use CTApi\Exceptions\CTAuthException;
 use CTApi\Exceptions\CTRequestException;
 use CTApi\Models\Groups\Person\Person;
 use CTApi\Utils\CTResponseUtil;
+use GuzzleHttp\Cookie\SetCookie;
 
 class AuthRequestBuilder
 {
@@ -74,12 +75,13 @@ class AuthRequestBuilder
     public function authWithSessionCookie(string $cookieString): Auth
     {
         $client = CTClient::getClient();
+        $cookie = SetCookie::fromString($cookieString);
 
         try {
             $response = $client->get('/api/whoami', [
                 'headers' => [
-                    'cookie' => $cookieString,
-                ]
+                    'cookie' => $cookie->getName() . '=' . $cookie->getValue(),
+                ],
             ]);
             $data = CTResponseUtil::dataAsArray($response);
             $person = Person::createModelFromData($data);

--- a/src/Models/Common/Auth/AuthRequestBuilder.php
+++ b/src/Models/Common/Auth/AuthRequestBuilder.php
@@ -71,6 +71,28 @@ class AuthRequestBuilder
         throw new CTAuthException("Authentication was not successfull.");
     }
 
+    public function authWithSessionCookie(string $cookieString): Auth
+    {
+        $client = CTClient::getClient();
+
+        try {
+            $response = $client->get('/api/whoami', [
+                'headers' => [
+                    'cookie' => $cookieString,
+                ]
+            ]);
+            $data = CTResponseUtil::dataAsArray($response);
+            $person = Person::createModelFromData($data);
+        } catch (CTRequestException $exception) {
+            throw new CTAuthException("Authentication was not successfull: " . $exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        if ($person->getId() != null && $person->getId() != -1 && $person->getId() != "-1") {
+            return new Auth($person->getId(), false);
+        }
+        throw new CTAuthException("Authentication was not successfull.");
+    }
+
     public function authWithUserIdAndLoginToken(string $userId, string $loginToken): bool
     {
         $client = CTClient::getClient();

--- a/tests/Integration/Requests/AuthRequestTest.php
+++ b/tests/Integration/Requests/AuthRequestTest.php
@@ -42,12 +42,20 @@ class AuthRequestTest extends TestCase
         CTConfig::setApiUrl(IntegrationTestData::get()->getApiUrl());
 
         // verify that we are not logged in now
-        $this->assertFalse(CTConfig::validateAuthentication());
+        $this->assertNull(CTConfig::getSessionCookieString());
 
         // login using the cookie
         $auth = CTConfig::authWithSessionCookie($cookie);
-        $this->assertSame($userId, $auth->userId);
+        $this->assertEquals($userId, $auth->userId);
         $this->assertTrue(CTConfig::validateAuthentication());
+
+        // confirm we are still logged in
+        $authValid = CTConfig::validateAuthentication();
+        $this->assertTrue($authValid);
+
+        // confirm the session cookie was updated (but not replaced)
+        $updatedCookie = CTConfig::getSessionCookieString();
+        $this->assertSame(explode(';', $cookie, 2)[0], explode(';', $updatedCookie, 2)[0]);
     }
 
     public function testAuthWithUserIdAndLoginToken()

--- a/tests/Integration/Requests/AuthRequestTest.php
+++ b/tests/Integration/Requests/AuthRequestTest.php
@@ -28,6 +28,28 @@ class AuthRequestTest extends TestCase
         $this->assertNotNull($cookie);
     }
 
+    public function testAuthWithSessionCookie(): void
+    {
+        $auth = IntegrationTestData::get()->authenticateUser();
+        $userId = $auth->userId;
+        $this->assertNotNull($userId);
+
+        $cookie = CTConfig::getSessionCookieString();
+        $this->assertNotNull($cookie);
+
+        // clear config
+        CTConfig::clearConfig();
+        CTConfig::setApiUrl(IntegrationTestData::get()->getApiUrl());
+
+        // verify that we are not logged in now
+        $this->assertFalse(CTConfig::validateAuthentication());
+
+        // login using the cookie
+        $auth = CTConfig::authWithSessionCookie($cookie);
+        $this->assertSame($userId, $auth->userId);
+        $this->assertTrue(CTConfig::validateAuthentication());
+    }
+
     public function testAuthWithUserIdAndLoginToken()
     {
         $auth = IntegrationTestData::get()->authenticateUser();

--- a/tests/Integration/Requests/AuthRequestTest.php
+++ b/tests/Integration/Requests/AuthRequestTest.php
@@ -38,11 +38,14 @@ class AuthRequestTest extends TestCase
         $this->assertNotNull($cookie);
 
         // clear config
-        CTConfig::clearConfig();
-        CTConfig::setApiUrl(IntegrationTestData::get()->getApiUrl());
+        CTConfig::clearCookies();
 
         // verify that we are not logged in now
-        $this->assertNull(CTConfig::getSessionCookieString());
+        CTConfig::setApiUrl(IntegrationTestData::get()->getApiUrl());
+        $this->assertFalse(CTConfig::validateAuthentication());
+
+        // clear again
+        CTConfig::clearCookies();
 
         // login using the cookie
         $auth = CTConfig::authWithSessionCookie($cookie);
@@ -55,6 +58,7 @@ class AuthRequestTest extends TestCase
 
         // confirm the session cookie was updated (but not replaced)
         $updatedCookie = CTConfig::getSessionCookieString();
+        $this->assertNotNull($updatedCookie);
         $this->assertSame(explode(';', $cookie, 2)[0], explode(';', $updatedCookie, 2)[0]);
     }
 


### PR DESCRIPTION
This package already handles session cookies for authentication between requests. With these few changes, the session cookie string can be extracted (to be stored elsewhere) and re-used at a later time. The suggested login flow follows that of authentication by login token, verifying the session cookie through an attempted call to `whoami`.

I've tested this against my own CT instance, I'm not sure about the official integration tests of this package though (I'll try to provide tests).