### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,16 @@
 composer.phar
 
 # ignore testdata with credentials
-/tests/integration/testdata.ini
-/tests/integration/integration.ini
+/tests/Integration/testdata.ini
+/tests/Integration/integration.ini
 # ignore ide configuration
 .idea/
 
 # ignore phpunit-cache
 .phpunit.result.cache
+
+# ignore php-cs-fixer cache
+.php-cs-fixer.cache
 
 # ignore log-files
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix GroupHierarchie test, Fix DB-Fields test ([PR192](https://github.com/5pm-HDH/churchtools-api/pull/192), [PR194](https://github.com/5pm-HDH/churchtools-api/pull/194))
 - Fix breaking changes Event-API ([PR196](https://github.com/5pm-HDH/churchtools-api/pull/196))
 - Issue search for person ([PR210](https://github.com/5pm-HDH/churchtools-api/pull/210))
+- Fix issue with changelog ([PR213](https://github.com/5pm-HDH/churchtools-api/pull/213))
 
 ## [2.0.0]
 

--- a/tests/Integration/Requests/SongCommentRequestTest.php
+++ b/tests/Integration/Requests/SongCommentRequestTest.php
@@ -13,6 +13,7 @@ class SongCommentRequestTest extends TestCaseAuthenticated
     protected function setUp(): void
     {
         parent::setUp();
+        $this->markTestSkipped('Broken implementation of churchtools todo in #215');
         $this->arrangementId = IntegrationTestData::getFilterAsInt("get_song_comments", "song_arrangement_id");
     }
 

--- a/tests/Integration/Requests/SongCommentRequestTest.php
+++ b/tests/Integration/Requests/SongCommentRequestTest.php
@@ -13,8 +13,8 @@ class SongCommentRequestTest extends TestCaseAuthenticated
     protected function setUp(): void
     {
         parent::setUp();
-        $this->markTestSkipped('Broken implementation of churchtools todo in #215');
         $this->arrangementId = IntegrationTestData::getFilterAsInt("get_song_comments", "song_arrangement_id");
+        $this->markTestSkipped('Broken implementation of churchtools todo in #215');
     }
 
     public function testGetSongArrangement()


### PR DESCRIPTION
Just a tiny fix I came across while working on https://github.com/5pm-HDH/churchtools-api/pull/207

Git is case sensitive to paths, therefore the paths to tests/Integration need to be corrected.