### PR TITLE
Ignore empty strings when creating new records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Fixed
+- Ignore empty strings when creating new records ([PR220](https://github.com/5pm-HDH/churchtools-api/pull/220))
 
 ### Fixed - ChurchTools Breaking Change
 

--- a/src/Models/AbstractRequestBuilder.php
+++ b/src/Models/AbstractRequestBuilder.php
@@ -78,10 +78,10 @@ abstract class AbstractRequestBuilder
         $allData = $model->extractData();
         $data = array_intersect_key($allData, array_flip($createAttributes));
 
-        // We can remove null values from the data, because they are irrelevant
+        // We can remove empty values from the data, because they are irrelevant
         // for the creation of a new data record.
         $data = array_filter($data, function ($value) {
-            return !is_null($value);
+            return !is_null($value) && $value !== '';
         });
 
         $responseData = $this->createData($data, $force);


### PR DESCRIPTION
When sending an empty string as e-mail on creation of a new person, the following exception is thrown:

> In CTRequestException.php line 130: There are validation errors. Field 'email' has to be a valid e-mail of type string. Provided value was ''.

This change fixes it.