### PR TITLE
adapt tag Api calls (replaced deprecated and rework song tags)

### DIFF
--- a/src/Models/Common/Tag/TagRequest.php
+++ b/src/Models/Common/Tag/TagRequest.php
@@ -6,31 +6,46 @@ class TagRequest
 {
     public static function allPersonTags(): array
     {
-        return (new TagRequestBuilder("persons"))->all();
+        return (new TagRequestBuilder("person"))->all();
     }
 
     public static function allSongTags(): array
     {
-        return (new TagRequestBuilder("songs"))->all();
+        return (new TagRequestBuilder("song"))->all();
+    }
+    
+    public static function allGroupTags(): array
+    {
+        return (new TagRequestBuilder("group"))->all();
     }
 
     public static function findPersonTag(int $id): ?Tag
     {
-        return (new TagRequestBuilder("persons"))->find($id);
+        return (new TagRequestBuilder("person"))->find($id);
     }
 
     public static function findSongTag(int $id): ?Tag
     {
-        return (new TagRequestBuilder("songs"))->find($id);
+        return (new TagRequestBuilder("song"))->find($id);
+    }
+    
+    public static function findGroupTag(int $id): ?Tag
+    {
+        return (new TagRequestBuilder("group"))->find($id);
     }
 
     public static function findPersonTagOrFail(int $id): Tag
     {
-        return (new TagRequestBuilder("persons"))->findOrFail($id);
+        return (new TagRequestBuilder("person"))->findOrFail($id);
     }
 
     public static function findSongTagOrFail(int $id): Tag
     {
-        return (new TagRequestBuilder("songs"))->findOrFail($id);
+        return (new TagRequestBuilder("song"))->findOrFail($id);
+    }
+    
+    public static function findGroupTagOrFail(int $id): Tag
+    {
+        return (new TagRequestBuilder("group"))->findOrFail($id);
     }
 }

--- a/src/Models/Common/Tag/TagRequestBuilder.php
+++ b/src/Models/Common/Tag/TagRequestBuilder.php
@@ -19,7 +19,7 @@ class TagRequestBuilder
     private function retrieveData(): array
     {
         $client = CTClient::getClient();
-        $response = $client->get("/api/tags", ["query" => ["type" => $this->type]]);
+        $response = $client->get("/api/tags/".$this->type);
         $data = CTResponseUtil::dataAsArray($response);
         return Tag::createModelsFromArray($data);
     }

--- a/src/Models/Events/Song/SongTagRequestBuilder.php
+++ b/src/Models/Events/Song/SongTagRequestBuilder.php
@@ -2,14 +2,12 @@
 
 namespace CTApi\Models\Events\Song;
 
-use CTApi\Models\Common\Tag\TagRequestBuilder;
-use CTApi\Traits\Request\AjaxApi;
+use CTApi\CTClient;
+use CTApi\Models\Common\Tag\Tag;
 use CTApi\Utils\CTResponseUtil;
 
 class SongTagRequestBuilder
 {
-    use AjaxApi;
-
     public function __construct(
         private int $songId
     ) {
@@ -17,36 +15,10 @@ class SongTagRequestBuilder
 
     public function get(): array
     {
-        $songData = $this->getTagData();
-        $songId = $this->songId;
-        $filteredSongs = array_filter($songData, function ($song) use ($songId) {
-            return $song["id"] == $songId;
-        });
-        $songElement = end($filteredSongs);
-
-        if ($songElement === false) {
-            return [];
-        }
-
-        $tags = $songElement["tags"] ?? [];
-
-        $tagRequestBuilder = new TagRequestBuilder("songs");
-
-        $tagsAsObjects = array_map(function ($tagId) use ($tagRequestBuilder) {
-            return $tagRequestBuilder->find($tagId);
-        }, $tags);
-        return $tagsAsObjects;
-    }
-
-    private function getTagData(): array
-    {
-        $response = $this->requestAjax("churchservice/ajax", "getAllSongs", []);
+        
+        $client = CTClient::getClient();
+        $response = $client->get('/api/tags/song/'.$this->songId);
         $data = CTResponseUtil::dataAsArray($response);
-
-        if(array_key_exists("songs", $data)) {
-            return $data["songs"];
-        } else {
-            return $data;
-        }
+        return Tag::createModelsFromArray($data);
     }
 }

--- a/src/Models/Groups/Group/GroupTagRequestBuilder.php
+++ b/src/Models/Groups/Group/GroupTagRequestBuilder.php
@@ -16,7 +16,7 @@ class GroupTagRequestBuilder
     public function get(): array
     {
         $client = CTClient::getClient();
-        $response = $client->get('/api/groups/'.$this->groupId.'/tags');
+        $response = $client->get('/api/tags/group/'.$this->groupId);
         $data = CTResponseUtil::dataAsArray($response);
         return Tag::createModelsFromArray($data);
     }

--- a/src/Models/Groups/Person/PersonTagRequestBuilder.php
+++ b/src/Models/Groups/Person/PersonTagRequestBuilder.php
@@ -16,7 +16,7 @@ class PersonTagRequestBuilder
     public function get(): array
     {
         $client = CTClient::getClient();
-        $response = $client->get('/api/persons/'.$this->personId.'/tags');
+        $response = $client->get('/api/tags/person/'.$this->personId);
         $data = CTResponseUtil::dataAsArray($response);
         return Tag::createModelsFromArray($data);
     }


### PR DESCRIPTION
There are some deprecated API endpoints for tags:
* /persons/{personId}/tags is replaced by /tags/person/{personId}
* /groups/{groupId}/tags is replaced by /tags/group/{groupId}
* /tags?type={type} is replaced by /tags/{type}  (will be removed from CT at 2025/07/22)
* new tag type "group"
* new endpoint: /tags/song/{songId} to get tags of a song: SongTagRequestBuilder changed to use it and remove call to AJAX API (getAllSongs)

information about all deprecated  API functions: https://churchtools.academy/de/help/system-einstellungen/api/0-deprecations/