### PR TITLE
Adapt fields (deprecated and missing fields)

### DIFF
--- a/src/Models/Events/Event/Event.php
+++ b/src/Models/Events/Event/Event.php
@@ -31,6 +31,7 @@ class Event extends AbstractModel
     protected ?EventAgenda $agenda = null;
     protected ?array $eventServices = [];
     protected ?array $adminIds = [];
+    protected ?array $eventFiles = [];
 
     protected function fillArrayType(string $key, array $data): void
     {
@@ -51,6 +52,12 @@ class Event extends AbstractModel
                 break;
             case "adminIds":
                 $this->setAdminIds($data);
+                break;
+            case "eventAdminIds":
+                //deprecated field
+                break;
+            case "eventFiles":
+                $this->setEventFiles(DomainAttributeModel::createModelsFromArray($data));
                 break;
             default:
                 $this->fillDefault($key, $data);
@@ -327,6 +334,24 @@ class Event extends AbstractModel
     public function setEventServices(?array $eventServices): Event
     {
         $this->eventServices = $eventServices;
+        return $this;
+    }
+    
+    /**
+     * @return array|null
+     */
+    public function getEventFiles(): ?array
+    {
+        return $this->eventFiles;
+    }
+    
+    /**
+     * @param array|null $eventFiles
+     * @return Event
+     */
+    public function setEventFiles(?array $eventFiles): Event
+    {
+        $this->eventFiles = $eventFiles;
         return $this;
     }
 

--- a/src/Models/Events/Service/EventService.php
+++ b/src/Models/Events/Service/EventService.php
@@ -24,6 +24,14 @@ class EventService extends AbstractModel
     protected ?string $comment = null;
     protected ?string $counter = null;
     protected ?bool $allowChat = null;
+    
+    protected function fillNonArrayType(string $key, $value): void
+    {
+        if ($key == "permissions" || $key == "event")
+            //empty/unused fields
+            return;
+        $this->fillDefault($key, $value);
+    }
 
     protected function fillArrayType(string $key, array $data): void
     {

--- a/src/Models/Events/Song/Song.php
+++ b/src/Models/Events/Song/Song.php
@@ -15,14 +15,8 @@ class Song extends AbstractModel implements UpdatableModel
     use MetaAttribute;
     use ExtractData;
 
-    /**
-     * @deprecated not filled by CT anymore
-     */
     protected ?string $arrangementId = null;
     protected ?string $name = null;
-    /**
-     * @deprecated not filled by CT anymore
-     */
     protected ?string $arrangement = null;
     protected array $arrangements = [];
     protected ?SongCategory $category = null;
@@ -38,17 +32,8 @@ class Song extends AbstractModel implements UpdatableModel
      * @deprecated
      */
     protected ?string $note = null;
-    /**
-     * @deprecated not filled by CT anymore
-     */
     protected ?string $key = null;
-    /**
-     * @deprecated not filled by CT anymore
-     */
     protected ?string $bpm = null;
-    /**
-     * @deprecated not filled by CT anymore
-     */
     protected ?bool $isDefault = null;
 
     public static function getModifiableAttributes(): array
@@ -140,7 +125,6 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
-     * @deprecated not filled by CT anymore
      */
     public function getArrangementId(): ?string
     {
@@ -150,7 +134,6 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $arrangementId
      * @return Song
-     * @deprecated not filled by CT anymore
      */
     public function setArrangementId(?string $arrangementId): Song
     {
@@ -178,7 +161,6 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
-     * @deprecated not filled by CT anymore
      */
     public function getArrangement(): ?string
     {
@@ -188,7 +170,6 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $arrangement
      * @return Song
-     * @deprecated not filled by CT anymore
      */
     public function setArrangement(?string $arrangement): Song
     {
@@ -346,7 +327,6 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
-     * @deprecated not filled by CT anymore
      */
     public function getKey(): ?string
     {
@@ -356,7 +336,6 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $key
      * @return Song
-     * @deprecated not filled by CT anymore
      */
     public function setKey(?string $key): Song
     {
@@ -366,7 +345,6 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
-     * @deprecated not filled by CT anymore
      */
     public function getBpm(): ?string
     {
@@ -376,7 +354,6 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $bpm
      * @return Song
-     * @deprecated not filled by CT anymore
      */
     public function setBpm(?string $bpm): Song
     {

--- a/src/Models/Events/Song/Song.php
+++ b/src/Models/Events/Song/Song.php
@@ -15,19 +15,40 @@ class Song extends AbstractModel implements UpdatableModel
     use MetaAttribute;
     use ExtractData;
 
+    /**
+     * @deprecated not filled by CT anymore
+     */
     protected ?string $arrangementId = null;
     protected ?string $name = null;
+    /**
+     * @deprecated not filled by CT anymore
+     */
     protected ?string $arrangement = null;
     protected array $arrangements = [];
     protected ?SongCategory $category = null;
+    /**
+     * @deprecated use $category->getId()
+     */
     protected ?string $category_id = null;
     protected ?bool $shouldPractice = null;
     protected ?string $author = null;
     protected ?string $ccli = null;
     protected ?string $copyright = null;
+    /**
+     * @deprecated
+     */
     protected ?string $note = null;
+    /**
+     * @deprecated not filled by CT anymore
+     */
     protected ?string $key = null;
+    /**
+     * @deprecated not filled by CT anymore
+     */
     protected ?string $bpm = null;
+    /**
+     * @deprecated not filled by CT anymore
+     */
     protected ?bool $isDefault = null;
 
     public static function getModifiableAttributes(): array
@@ -41,7 +62,7 @@ class Song extends AbstractModel implements UpdatableModel
             "ccli"
         ];
     }
-
+    
     protected function fillArrayType(string $key, array $data): void
     {
         switch ($key) {
@@ -68,9 +89,6 @@ class Song extends AbstractModel implements UpdatableModel
                 break;
             case "title":
                 $this->setName($value);
-                break;
-            case "category":
-                $this->setCategory(SongCategory::createModelFromData(["name" => $value]));
                 break;
             default:
                 $this->fillDefault($key, $value);
@@ -122,6 +140,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getArrangementId(): ?string
     {
@@ -131,6 +150,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $arrangementId
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setArrangementId(?string $arrangementId): Song
     {
@@ -158,6 +178,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getArrangement(): ?string
     {
@@ -167,6 +188,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $arrangement
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setArrangement(?string $arrangement): Song
     {
@@ -212,6 +234,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getCategoryId(): ?string
     {
@@ -221,6 +244,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $category_id
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setCategoryId(?string $category_id): Song
     {
@@ -302,6 +326,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getNote(): ?string
     {
@@ -311,6 +336,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $note
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setNote(?string $note): Song
     {
@@ -320,6 +346,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getKey(): ?string
     {
@@ -329,6 +356,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $key
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setKey(?string $key): Song
     {
@@ -338,6 +366,7 @@ class Song extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated not filled by CT anymore
      */
     public function getBpm(): ?string
     {
@@ -347,6 +376,7 @@ class Song extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $bpm
      * @return Song
+     * @deprecated not filled by CT anymore
      */
     public function setBpm(?string $bpm): Song
     {

--- a/src/Models/Events/Song/SongArrangement.php
+++ b/src/Models/Events/Song/SongArrangement.php
@@ -37,6 +37,9 @@ class SongArrangement extends AbstractModel implements UpdatableModel
      */
     protected ?string $note = null;
     protected ?string $description = null;
+    protected ?string $sourceName = null;
+    protected ?string $sourceReference = null;
+    
     protected array $links = [];
     protected array $files = [];
 
@@ -52,14 +55,6 @@ class SongArrangement extends AbstractModel implements UpdatableModel
         ];
     }
 
-    protected function fillNonArrayType(string $key, $value): void
-    {
-        if ($key == "sourceReference" || $key == "sourceName")
-            //empty/unused fields
-            return;
-        $this->fillDefault($key, $value);
-    }
-    
     protected function fillArrayType(string $key, array $data): void
     {
         switch ($key) {
@@ -319,6 +314,42 @@ class SongArrangement extends AbstractModel implements UpdatableModel
     public function setDescription(?string $description): SongArrangement
     {
         $this->description = $description;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getSourceName(): ?string
+    {
+        return $this->sourceName;
+    }
+    
+    /**
+     * @param string|null $sourceName
+     * @return SongArrangement
+     */
+    public function setSourceName(?string $sourceName): SongArrangement
+    {
+        $this->sourceName = $sourceName;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getSourceReference(): ?string
+    {
+        return $this->sourceReference;
+    }
+    
+    /**
+     * @param string|null $sourceReference
+     * @return SongArrangement
+     */
+    public function setSourceReference(?string $sourceReference): SongArrangement
+    {
+        $this->sourceReference = $sourceReference;
         return $this;
     }
 

--- a/src/Models/Events/Song/SongArrangement.php
+++ b/src/Models/Events/Song/SongArrangement.php
@@ -20,11 +20,23 @@ class SongArrangement extends AbstractModel implements UpdatableModel
 
     protected ?string $name = null;
     protected ?bool $isDefault = null;
+    /**
+     * @deprecated use key instead
+     */
     protected ?string $keyOfArrangement = null;
+    protected ?string $key = null;
+    /**
+     * @deprecated use tempo instead
+     */
     protected ?string $bpm = null;
+    protected ?string $tempo = null;
     protected ?string $beat = null;
     protected ?string $duration = null;
+    /**
+     * @deprecated use description instead
+     */
     protected ?string $note = null;
+    protected ?string $description = null;
     protected array $links = [];
     protected array $files = [];
 
@@ -40,6 +52,14 @@ class SongArrangement extends AbstractModel implements UpdatableModel
         ];
     }
 
+    protected function fillNonArrayType(string $key, $value): void
+    {
+        if ($key == "sourceReference" || $key == "sourceName")
+            //empty/unused fields
+            return;
+        $this->fillDefault($key, $value);
+    }
+    
     protected function fillArrayType(string $key, array $data): void
     {
         switch ($key) {
@@ -151,9 +171,28 @@ class SongArrangement extends AbstractModel implements UpdatableModel
         $this->isDefault = $isDefault;
         return $this;
     }
+    
+    /**
+     * @return string|null
+     */
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+    
+    /**
+     * @param string|null $key
+     * @return SongArrangement
+     */
+    public function setKey(?string $key): SongArrangement
+    {
+        $this->key = $key;
+        return $this;
+    }
 
     /**
      * @return string|null
+     * @deprecated use key instead
      */
     public function getKeyOfArrangement(): ?string
     {
@@ -163,6 +202,7 @@ class SongArrangement extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $keyOfArrangement
      * @return SongArrangement
+     * @deprecated use key instead
      */
     public function setKeyOfArrangement(?string $keyOfArrangement): SongArrangement
     {
@@ -173,6 +213,25 @@ class SongArrangement extends AbstractModel implements UpdatableModel
     /**
      * @return string|null
      */
+    public function getTempo() : ?string
+    {
+        return $this->tempo;
+    }
+    
+    /**
+     * @param string|null $tempo
+     * @return SongArrangement
+     */
+    public function setTempo($tempo) : SongArrangement
+    {
+        $this->tempo = $tempo;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     * @deprecated use tempo instead
+     */
     public function getBpm(): ?string
     {
         return $this->bpm;
@@ -181,6 +240,7 @@ class SongArrangement extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $bpm
      * @return SongArrangement
+     * @deprecated use tempo instead
      */
     public function setBpm(?string $bpm): SongArrangement
     {
@@ -226,6 +286,7 @@ class SongArrangement extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated use description instead
      */
     public function getNote(): ?string
     {
@@ -235,10 +296,29 @@ class SongArrangement extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $note
      * @return SongArrangement
+     * @deprecated use description instead
      */
     public function setNote(?string $note): SongArrangement
     {
         $this->note = $note;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+    
+    /**
+     * @param string|null $description
+     * @return SongArrangement
+     */
+    public function setDescription(?string $description): SongArrangement
+    {
+        $this->description = $description;
         return $this;
     }
 

--- a/src/Models/Groups/Group/GroupRole.php
+++ b/src/Models/Groups/Group/GroupRole.php
@@ -11,22 +11,32 @@ class GroupRole extends AbstractModel
 
     protected ?string $groupTypeId = null;
     protected ?string $name = null;
+    protected ?string $nameTranslated = null;
     protected ?string $shorty = null;
-    protected ?string $type = null;
-    protected ?string $receiveQRCode = null;
     protected ?string $sortKey = null;
-    protected ?bool $toDelete = null;
-    protected ?bool $hasRequested = null;
     protected ?bool $isLeader = null;
+    protected ?string $type = null;
     protected ?bool $isDefault = null;
     protected ?bool $isHidden = null;
-    protected ?string $growPathId = null;
-    protected ?string $groupTypeRoleId = null;
+    protected ?int $growPathId = null;
+    protected ?int $groupTypeRoleId = null;
     protected ?bool $forceTwoFactorAuth = null;
+    protected ?string $receiveQRCode = null;
     protected ?bool $isActive = null;
+    protected ?bool $countsTowardsSeats	= null;
     protected ?bool $canReadChat = null;
     protected ?bool $canWriteChat = null;
-
+    protected ?array $htmlTemplateIds = null;
+    
+    /**
+     * @deprecated not filled anymore by CT
+     */
+    protected ?bool $toDelete = null;
+    /**
+     * @deprecated not filled anymore by CT
+     */
+    protected ?bool $hasRequested = null;
+    
     /**
      * @param string|null $id
      * @return GroupRole
@@ -72,6 +82,24 @@ class GroupRole extends AbstractModel
         $this->name = $name;
         return $this;
     }
+    
+    /**
+     * @return string|null
+     */
+    public function getNameTranslated(): ?string
+    {
+        return $this->nameTranslated;
+    }
+    
+    /**
+     * @param string|null $nameTranslated
+     * @return GroupRole
+     */
+    public function setNameTranslated(?string $nameTranslated): GroupRole
+    {
+        $this->nameTranslated = $nameTranslated;
+        return $this;
+    }
 
     /**
      * @return string|null
@@ -111,6 +139,7 @@ class GroupRole extends AbstractModel
 
     /**
      * @return bool|null
+     * @deprecated not filled anymore by CT
      */
     public function getToDelete(): ?bool
     {
@@ -120,6 +149,7 @@ class GroupRole extends AbstractModel
     /**
      * @param bool|null $toDelete
      * @return GroupRole
+     * @deprecated not filled anymore by CT
      */
     public function setToDelete(?bool $toDelete): GroupRole
     {
@@ -129,6 +159,7 @@ class GroupRole extends AbstractModel
 
     /**
      * @return bool|null
+     * @deprecated not filled anymore by CT
      */
     public function getHasRequested(): ?bool
     {
@@ -138,6 +169,7 @@ class GroupRole extends AbstractModel
     /**
      * @param bool|null $hasRequested
      * @return GroupRole
+     * @deprecated not filled anymore by CT
      */
     public function setHasRequested(?bool $hasRequested): GroupRole
     {
@@ -200,36 +232,36 @@ class GroupRole extends AbstractModel
     }
 
     /**
-     * @return string|null
+     * @return int|null
      */
-    public function getGrowPathId(): ?string
+    public function getGrowPathId(): ?int
     {
         return $this->growPathId;
     }
 
     /**
-     * @param string|null $growPathId
+     * @param int|null $growPathId
      * @return GroupRole
      */
-    public function setGrowPathId(?string $growPathId): GroupRole
+    public function setGrowPathId(?int $growPathId): GroupRole
     {
         $this->growPathId = $growPathId;
         return $this;
     }
 
     /**
-     * @return string|null
+     * @return int|null
      */
-    public function getGroupTypeRoleId(): ?string
+    public function getGroupTypeRoleId(): ?int
     {
         return $this->groupTypeRoleId;
     }
 
     /**
-     * @param string|null $groupTypeRoleId
+     * @param int|null $groupTypeRoleId
      * @return GroupRole
      */
-    public function setGroupTypeRoleId(?string $groupTypeRoleId): GroupRole
+    public function setGroupTypeRoleId(?int $groupTypeRoleId): GroupRole
     {
         $this->groupTypeRoleId = $groupTypeRoleId;
         return $this;
@@ -304,6 +336,42 @@ class GroupRole extends AbstractModel
     public function setCanWriteChat(?bool $canWriteChat): GroupRole
     {
         $this->canWriteChat = $canWriteChat;
+        return $this;
+    }
+    
+    /**
+     * @return bool|null
+     */
+    public function getCountsTowardsSeats(): ?bool
+    {
+        return $this->countsTowardsSeats;
+    }
+    
+    /**
+     * @param bool|null $canWriteChat
+     * @return GroupRole
+     */
+    public function setCountsTowardsSeats(?bool $countsTowardsSeats): GroupRole
+    {
+        $this->countsTowardsSeats = $countsTowardsSeats;
+        return $this;
+    }
+    
+    /**
+     * @return array|null
+     */
+    public function getHtmlTemplateIds(): ?array
+    {
+        return $this->htmlTemplateIds;
+    }
+    
+    /**
+     * @param array|null $canWriteChat
+     * @return GroupRole
+     */
+    public function setHtmlTemplateIds(?array $htmlTemplateIds): GroupRole
+    {
+        $this->htmlTemplateIds = $htmlTemplateIds;
         return $this;
     }
 }

--- a/src/Models/Groups/Group/GroupSettings.php
+++ b/src/Models/Groups/Group/GroupSettings.php
@@ -3,26 +3,45 @@
 namespace CTApi\Models\Groups\Group;
 
 use CTApi\Traits\Model\FillWithData;
+use CTApi\Utils\CTDateTimeService;
 
 class GroupSettings
 {
     use FillWithData;
 
+    protected ?bool $allowChildRegistration = null;
+    protected ?bool $allowOtherRegistration = null;
+    protected ?bool $allowSameEmailRegistration = null;
+    protected ?bool $allowSpouseRegistration = null;
+    protected ?bool $allowWaitinglist = null;
+    protected ?bool $autoAccept = null;
+    protected ?bool $automaticMoveUp = null;
+    protected ?bool $defaultPostCommentsActive = null;
+    protected ?string $defaultPostNotificationScope = null;
+    protected ?string $defaultPostPlaceholderText = null;
+    protected ?string $defaultPostVisibility = null;
+    protected ?array $dynamicGroupRuleSet = null;
+    protected ?string $dynamicGroupStatus = null;
+    protected ?string $dynamicGroupUpdateFinished = null;
+    protected ?string $dynamicGroupUpdateStarted = null; 
+    protected ?bool $externalPostSubscriptionsEnabled = null;
+    protected array $groupMeeting = [];
+    protected ?bool $inStatistic = null;
+    protected ?bool $informLeader = null;
     protected ?bool $isHidden = null;
     protected ?bool $isOpenForMembers = null;
-    protected ?bool $allowSpouseRegistration = null;
-    protected ?bool $allowChildRegistration = null;
-    protected ?bool $allowSameEmailRegistration = null;
-    protected ?bool $allowOtherRegistration = null;
-    protected ?bool $autoAccept = null;
-    protected ?bool $allowWaitinglist = null;
-    protected ?string $waitinglistMaxPersons = null;
-    protected ?bool $automaticMoveUp = null;
     protected ?bool $isPublic = null;
-    protected array $groupMeeting = [];
-    protected ?bool $qrCodeCheckin = null;
     protected array $newMember = [];
-
+    protected ?bool $postsEnabled = null;
+    protected ?bool $qrCodeCheckin = null;
+    protected ?bool $qrCodeCheckinAutomaticEmail = null; 
+    protected ?bool $showStreet = null;
+    protected ?string $signUpClosingDate = null; 
+    protected ?string $signUpHeadline = null;
+    protected ?string $signUpOpeningDate = null; 
+    protected ?string $visibility = null;
+    protected ?string $waitinglistMaxPersons = null;
+    
     /**
      * @return bool|null
      */
@@ -272,6 +291,350 @@ class GroupSettings
     public function setNewMember(array $newMember): GroupSettings
     {
         $this->newMember = $newMember;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getDefaultPostCommentsActive(): ?bool
+    {
+        return $this->defaultPostCommentsActive;
+    }
+    
+    /**
+     * @param ?bool $defaultPostCommentsActive
+     * @return GroupSettings
+     */
+    public function setDefaultPostCommentsActive(?bool $defaultPostCommentsActive): GroupSettings
+    {
+        $this->defaultPostCommentsActive = $defaultPostCommentsActive;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDefaultPostNotificationScope(): ?string
+    {
+        return $this->defaultPostNotificationScope;
+    }
+    
+    /**
+     * @param ?string $defaultPostNotificationScope
+     * @return GroupSettings
+     */
+    public function setDefaultPostNotificationScope(?string $defaultPostNotificationScope): GroupSettings
+    {
+        $this->defaultPostNotificationScope = $defaultPostNotificationScope;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDefaultPostPlaceholderText(): ?string
+    {
+        return $this->defaultPostPlaceholderText;
+    }
+    
+    /**
+     * @param ?string $defaultPostPlaceholderText
+     * @return GroupSettings
+     */
+    public function setDefaultPostPlaceholderText(?string $defaultPostPlaceholderText): GroupSettings
+    {
+        $this->defaultPostPlaceholderText = $defaultPostPlaceholderText;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDefaultPostVisibility(): ?string
+    {
+        return $this->defaultPostVisibility;
+    }
+    
+    /**
+     * @param ?string $defaultPostVisibility
+     * @return GroupSettings
+     */
+    public function setDefaultPostVisibility(?string $defaultPostVisibility): GroupSettings
+    {
+        $this->defaultPostVisibility = $defaultPostVisibility;
+        return $this;
+    }
+    
+    /**
+     * @return ?array
+     */
+    public function getDynamicGroupRuleSet(): ?array
+    {
+        return $this->dynamicGroupRuleSet;
+    }
+    
+    /**
+     * @param ?array $dynamicGroupRuleSet
+     * @return GroupSettings
+     */
+    public function setDynamicGroupRuleSet(?array $dynamicGroupRuleSet): GroupSettings
+    {
+        $this->dynamicGroupRuleSet = $dynamicGroupRuleSet;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDynamicGroupStatus(): ?string
+    {
+        return $this->dynamicGroupStatus;
+    }
+    
+    /**
+     * @param ?string $dynamicGroupStatus
+     * @return GroupSettings
+     */
+    public function setDynamicGroupStatus(?string $dynamicGroupStatus): GroupSettings
+    {
+        $this->dynamicGroupStatus = $dynamicGroupStatus;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDynamicGroupUpdateFinished(): ?string
+    {
+        return $this->dynamicGroupUpdateFinished;
+    }
+    
+    /**
+     * @param ?string $dynamicGroupUpdateFinished
+     * @return GroupSettings
+     */
+    public function setDynamicGroupUpdateFinished(?string $dynamicGroupUpdateFinished): GroupSettings
+    {
+        $this->dynamicGroupUpdateFinished = $dynamicGroupUpdateFinished;
+        return $this;
+    }
+    
+    public function getDynamicGroupUpdateFinishedAsDateTime(): ?\DateTimeImmutable
+    {
+        return CTDateTimeService::stringToDateTime($this->dynamicGroupUpdateFinished);
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getDynamicGroupUpdateStarted(): ?string
+    {
+        return $this->dynamicGroupUpdateStarted;
+    }
+    
+    /**
+     * @param ?string $dynamicGroupUpdateStarted
+     * @return GroupSettings
+     */
+    public function setDynamicGroupUpdateStarted(?string $dynamicGroupUpdateStarted): GroupSettings
+    {
+        $this->dynamicGroupUpdateStarted = $dynamicGroupUpdateStarted;
+        return $this;
+    }
+    
+    public function getDynamicGroupUpdateStartedAsDateTime(): ?\DateTimeImmutable
+    {
+        return CTDateTimeService::stringToDateTime($this->dynamicGroupUpdateStarted);
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getExternalPostSubscriptionsEnabled(): ?bool
+    {
+        return $this->externalPostSubscriptionsEnabled;
+    }
+    
+    /**
+     * @param ?bool $externalPostSubscriptionsEnabled
+     * @return GroupSettings
+     */
+    public function setExternalPostSubscriptionsEnabled(?bool $externalPostSubscriptionsEnabled): GroupSettings
+    {
+        $this->externalPostSubscriptionsEnabled = $externalPostSubscriptionsEnabled;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getInStatistic(): ?bool
+    {
+        return $this->inStatistic;
+    }
+    
+    /**
+     * @param ?bool $inStatistic
+     * @return GroupSettings
+     */
+    public function setInStatistic(?bool $inStatistic): GroupSettings
+    {
+        $this->inStatistic = $inStatistic;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getInformLeader(): ?bool
+    {
+        return $this->informLeader;
+    }
+    
+    /**
+     * @param ?bool $inStatistic
+     * @return GroupSettings
+     */
+    public function setInformLeader(?bool $informLeader): GroupSettings
+    {
+        $this->informLeader = $informLeader;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getPostsEnabled(): ?bool
+    {
+        return $this->postsEnabled;
+    }
+    
+    /**
+     * @param ?bool $inStatistic
+     * @return GroupSettings
+     */
+    public function setPostsEnabled(?bool $postsEnabled): GroupSettings
+    {
+        $this->postsEnabled = $postsEnabled;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getQrCodeCheckinAutomaticEmail(): ?bool
+    {
+        return $this->qrCodeCheckinAutomaticEmail;
+    }
+    
+    /**
+     * @param ?bool $qrCodeCheckinAutomaticEmail
+     * @return GroupSettings
+     */
+    public function setQrCodeCheckinAutomaticEmail(?bool $qrCodeCheckinAutomaticEmail): GroupSettings
+    {
+        $this->qrCodeCheckinAutomaticEmail = $qrCodeCheckinAutomaticEmail;
+        return $this;
+    }
+    
+    /**
+     * @return ?bool
+     */
+    public function getShowStreet(): ?bool
+    {
+        return $this->showStreet;
+    }
+    
+    /**
+     * @param ?bool $showStreet
+     * @return GroupSettings
+     */
+    public function setShowStreet(?bool $showStreet): GroupSettings
+    {
+        $this->showStreet = $showStreet;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getSignUpClosingDate(): ?string
+    {
+        return $this->signUpClosingDate;
+    }
+    
+    /**
+     * @param ?string $signUpClosingDate
+     * @return GroupSettings
+     */
+    public function setSignUpClosingDate(?string $signUpClosingDate): GroupSettings
+    {
+        $this->signUpClosingDate = $signUpClosingDate;
+        return $this;
+    }
+    
+    public function getSignUpClosingDateAsDateTime(): ?\DateTimeImmutable
+    {
+        return CTDateTimeService::stringToDateTime($this->signUpClosingDate);
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getSignUpHeadline(): ?string
+    {
+        return $this->signUpHeadline;
+    }
+    
+    /**
+     * @param ?string $signUpClosingDate
+     * @return GroupSettings
+     */
+    public function setSignUpHeadline(?string $signUpHeadline): GroupSettings
+    {
+        $this->signUpHeadline = $signUpHeadline;
+        return $this;
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getSignUpOpeningDate(): ?string
+    {
+        return $this->signUpOpeningDate;
+    }
+    
+    /**
+     * @param ?string $signUpOpeningDate
+     * @return GroupSettings
+     */
+    public function setSignUpOpeningDate(?string $signUpOpeningDate): GroupSettings
+    {
+        $this->signUpOpeningDate = $signUpOpeningDate;
+        return $this;
+    }
+    
+    public function getSignUpOpeningDateAsDateTime(): ?\DateTimeImmutable
+    {
+        return CTDateTimeService::stringToDateTime($this->signUpOpeningDate);
+    }
+    
+    /**
+     * @return ?string
+     */
+    public function getVisibility(): ?string
+    {
+        return $this->visibility;
+    }
+    
+    /**
+     * @param ?string $visibility
+     * @return GroupSettings
+     */
+    public function setVisibility(?string $visibility): GroupSettings
+    {
+        $this->visibility = $visibility;
         return $this;
     }
 }

--- a/src/Models/Groups/GroupMember/GroupMember.php
+++ b/src/Models/Groups/GroupMember/GroupMember.php
@@ -9,16 +9,25 @@ use CTApi\Models\Groups\Person\PersonRequest;
 use CTApi\Traits\Model\ExtractData;
 use CTApi\Traits\Model\FillWithData;
 use CTApi\Utils\CTDateTimeService;
+use CTApi\Models\Common\Domain\DomainAttributeModel;
 
 class GroupMember extends AbstractModel implements UpdatableModel
 {
+    //TODO Adapt fields!
     use FillWithData;
     use ExtractData;
 
+    protected ?DomainAttributeModel $group = null;
+    /**
+     * @deprecated use $person->getId()
+     */
     protected ?string $personId = null;
     protected ?Person $person = null;
     protected ?string $groupTypeRoleId = null;
     protected ?string $groupMemberStatus = null;
+    protected ?string $roleChangedDate = null;
+    protected ?string $statusChangedDate = null;
+    protected ?int $registeredBy = null;
     protected ?string $followUpStep = null;
     protected ?string $followUpDiffDays = null;
     protected ?string $followUpUnsuccessfulBackGroupId = null;
@@ -35,6 +44,9 @@ class GroupMember extends AbstractModel implements UpdatableModel
         switch ($key) {
             case "person":
                 $this->setPerson(Person::createModelFromData($data));
+                break;
+            case "group":
+                $this->group = DomainAttributeModel::createModelFromData($data);
                 break;
             default:
                 $this->fillDefault($key, $data);
@@ -84,6 +96,7 @@ class GroupMember extends AbstractModel implements UpdatableModel
 
     /**
      * @return string|null
+     * @deprecated use $person->getId()
      */
     public function getPersonId(): ?string
     {
@@ -93,6 +106,7 @@ class GroupMember extends AbstractModel implements UpdatableModel
     /**
      * @param string|null $personId
      * @return GroupMember
+     * @deprecated use $person->getId()
      */
     public function setPersonId(?string $personId): GroupMember
     {
@@ -313,6 +327,60 @@ class GroupMember extends AbstractModel implements UpdatableModel
     public function setFollowUpUnsuccessfulBackGroupId(?string $followUpUnsuccessfulBackGroupId): GroupMember
     {
         $this->followUpUnsuccessfulBackGroupId = $followUpUnsuccessfulBackGroupId;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getRoleChangedDate(): ?string
+    {
+        return $this->roleChangedDate;
+    }
+    
+    /**
+     * @param string|null $roleChangedDay
+     * @return GroupMember
+     */
+    public function setRoleChangedDate(?string $roleChangedDay): GroupMember
+    {
+        $this->roleChangedDate = $roleChangedDay;
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getStatusChangedDate(): ?string
+    {
+        return $this->statusChangedDate;
+    }
+    
+    /**
+     * @param string|null $statusChangedDay
+     * @return GroupMember
+     */
+    public function setStatusChangedDate(?string $statusChangedDay): GroupMember
+    {
+        $this->statusChangedDate = $statusChangedDay;
+        return $this;
+    }
+    
+    /**
+     * @return int|null
+     */
+    public function getRegisteredBy(): ?int
+    {
+        return $this->registeredBy;
+    }
+    
+    /**
+     * @param int|null $registeredBy
+     * @return GroupMember
+     */
+    public function setRegisteredBy(?string $registeredBy): GroupMember
+    {
+        $this->registeredBy = $registeredBy;
         return $this;
     }
 }

--- a/src/Traits/Model/DomainAttribute.php
+++ b/src/Traits/Model/DomainAttribute.php
@@ -11,7 +11,11 @@ trait DomainAttribute
     protected ?string $frontendUrl = null;
     protected ?string $imageUrl = null;
     protected array $domainAttributes = [];
-
+    protected ?string $icon = null;
+    protected ?string $color = null;
+    protected ?string $initials = null;
+    protected array $infos = [];
+    
     /**
      * @return String|null
      */

--- a/src/Traits/Model/DomainAttribute.php
+++ b/src/Traits/Model/DomainAttribute.php
@@ -12,7 +12,7 @@ trait DomainAttribute
     protected ?string $imageUrl = null;
     protected array $domainAttributes = [];
     protected ?string $icon = null;
-    protected ?string $color = null;
+    protected ?array $color = null;
     protected ?string $initials = null;
     protected array $infos = [];
     
@@ -139,6 +139,24 @@ trait DomainAttribute
     public function setDomainAttributes(array $domainAttributes): self
     {
         $this->domainAttributes = $domainAttributes;
+        return $this;
+    }
+    
+    /**
+     * @return ?array
+     */
+    public function getColor(): ?array
+    {
+        return $this->color;
+    }
+    
+    /**
+     * @param array $color
+     * @return self
+     */
+    public function setColor(?array $color): self
+    {
+        $this->color = $color;
         return $this;
     }
 }

--- a/src/Traits/Model/FillWithData.php
+++ b/src/Traits/Model/FillWithData.php
@@ -73,6 +73,8 @@ trait FillWithData
     public function fillWithData(array $array): void
     {
         foreach ($array as $key => $value) {
+            if ($key == "@deprecated") 
+                continue;
             if (is_object($value)) {
                 $this->fillObjectType($key, $value);
             } elseif (is_array($value)) {
@@ -82,7 +84,7 @@ trait FillWithData
             }
         }
     }
-
+    
     protected function fillNonArrayType(string $key, $value): void
     {
         $this->fillDefault($key, $value);


### PR DESCRIPTION
Adapt some fields:

marked deprecated fields and added missing fields for classes:
- SongArrangements
- Song
- EventService
- DomainAttribute
- GroupRole
- GroupSettings
- GroupMember
- Event: call /events includes event files (as DomainAttributes): add them to model

Do not handle "@deprecated" field in FillWithData